### PR TITLE
Add assignee endpoint for view and update requests

### DIFF
--- a/authentication/permissions.py
+++ b/authentication/permissions.py
@@ -40,3 +40,14 @@ class IsOwnerOfRequest(BasePermission):
         except Request.DoesNotExist:
             raise Http404("Not found")
         return participant_request.owner.user == request.user
+
+
+class IsAssigneeOfRequest(BasePermission):
+    message = "You do not have the permission to manage this request"
+
+    def has_permission(self, request, view):
+        try:
+            participant_request = Request.objects.get(id=view.kwargs.get("pk", None))
+        except Request.DoesNotExist:
+            raise Http404("Not found")
+        return participant_request.assignee.user == request.user

--- a/authentication/tests.py
+++ b/authentication/tests.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from django.views import View
 from rest_framework import serializers
 
-from authentication.permissions import IsAffectedUser, IsHelperUser, IsOwnerOfRequest
+from authentication.permissions import IsAffectedUser, IsHelperUser, IsOwnerOfRequest, IsAssigneeOfRequest
 from authentication.serializer import EmailAuthTokenSerializer
 from crisis.models import Request
 
@@ -149,3 +149,28 @@ class IsOwnerOfRequestTest(TestCase):
         request = MockRequest()
         request.user = currentUser
         self.assertFalse(self.model.has_permission(request, self.viewMock))
+
+
+assignee_request = Mock()
+assignee_request.assignee = Mock()
+assignee_request.assignee.user = currentUser
+
+assignee_objects_mock = Mock()
+assignee_objects_mock.get.return_value = assignee_request
+
+assignee_success_request_mock = Mock(spec=Request)
+assignee_success_request_mock.objects = assignee_objects_mock
+
+
+class IsAssigneeOfRequestTest(TestCase):
+    def setUp(self) -> None:
+        self.model = IsAssigneeOfRequest()
+        self.viewMock = Mock(spec=View)
+        self.viewMock.kwargs = Mock()
+        self.viewMock.kwargs.get.return_value = None
+
+    @patch("authentication.permissions.Request", assignee_success_request_mock)
+    def test_owners_should_have_permission(self):
+        request = MockRequest()
+        request.user = currentUser
+        self.assertTrue(self.model.has_permission(request, self.viewMock))

--- a/crisis/models.py
+++ b/crisis/models.py
@@ -1,7 +1,6 @@
 # Create your models here.
 from django.core.exceptions import ValidationError
 from django.db import models
-
 # Create your models here.
 from django.db.models import fields
 from safedelete.models import SOFT_DELETE_CASCADE
@@ -29,14 +28,17 @@ class Request(SafeDeleteModel):
     _safedelete_policy = SOFT_DELETE_CASCADE
 
     TYPE_OF_REQUEST = [("G", "Grocery"), ("M", "Medicine")]
-    UNFINISHED_STATUSES = ["P", "T"]
-    FINISHED_STATUSES = ["F", "C"]
     STATUS_PENDING = "P"
+    STATUS_TRANSIT = "T"
+    STATUS_FINISHED = "F"
+    STATUS_CANCELLED = "C"
+    UNFINISHED_STATUSES = [STATUS_PENDING, STATUS_TRANSIT]
+    FINISHED_STATUSES = [STATUS_FINISHED, STATUS_CANCELLED]
     TYPE_OF_REQUEST_STATUSES = [
-        ("P", "Pending"),
-        ("T", "Transit"),
-        ("F", "Finished"),
-        ("C", "Cancelled"),
+        (STATUS_PENDING, "Pending"),
+        (STATUS_TRANSIT, "Transit"),
+        (STATUS_FINISHED, "Finished"),
+        (STATUS_CANCELLED, "Cancelled"),
     ]
     owner = models.ForeignKey(
         "management.Participant",

--- a/management/serializer.py
+++ b/management/serializer.py
@@ -42,7 +42,7 @@ class RequestSerializer(ModelSerializer):
             raise serializers.ValidationError("You cannot change this request anymore.")
 
         if self.instance.status == "T":
-            if attrs["status"] not in ["C", "F"]:
+            if attrs["status"] not in Request.FINISHED_STATUSES:
                 raise serializers.ValidationError(
                     "You can only cancel or mark the request as finished"
                 )
@@ -71,3 +71,31 @@ class RequestSerializer(ModelSerializer):
             "assignmentHistory",
             "created_at",
         )
+
+
+class AssigneeRequestUpdateSerializer(ModelSerializer):
+    class Meta:
+        model = Request
+        fields = (
+            "id",
+            "status"
+        )
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        if 'status' not in attrs:
+            raise serializers.ValidationError(
+                "Status is mandatory"
+            )
+
+        allowed_status = [
+            Request.STATUS_FINISHED,
+            Request.STATUS_PENDING,
+            Request.STATUS_TRANSIT
+        ]
+        if attrs["status"] not in allowed_status:
+            raise serializers.ValidationError(
+                "Only the following status are allowed %s" % str(allowed_status)
+            )
+
+        return attrs

--- a/management/tests.py
+++ b/management/tests.py
@@ -1,3 +1,62 @@
-from django.test import TestCase
+import json
 
-# Create your tests here.
+from django.test import TestCase, Client
+
+
+class AssignedRequestsTest(TestCase):
+    fixtures = ['fixtures/small.yaml']
+    token = None
+
+    def setUp(self) -> None:
+        self.client = Client()
+
+    def testAssignedRequestListEndpointExists(self):
+        response = self.client.get('/api/v1/me/assigned-requests/')
+        self.assertNotEqual(404, response.status_code)
+
+    def testAssignedRequestListEndpointRequiresAnAuthenticatedUser(self):
+        response = self.client.get('/api/v1/me/assigned-requests/')
+        self.assertEquals(401, response.status_code)
+
+        response = self.client.get('/api/v1/me/assigned-requests/',  HTTP_AUTHORIZATION='Token ' + self.get_token())
+        self.assertEquals(200, response.status_code)
+        self.assertEquals(1, response.json()['count'])
+
+    def testAssignedRequestViewEndpointExists(self):
+        response = self.client.get('/api/v1/me/assigned-requests/1')
+        self.assertEquals(401, response.status_code)
+
+    def testOnlyAssigneeCanSeeAssignedRequest(self):
+        response = self.client.get('/api/v1/me/assigned-requests/2',  HTTP_AUTHORIZATION='Token ' + self.get_token())
+        self.assertEquals(403, response.status_code)
+
+        response = self.client.get('/api/v1/me/assigned-requests/1', HTTP_AUTHORIZATION='Token ' + self.get_token())
+        self.assertEquals(200, response.status_code)
+        self.assertEquals(response.json()['id'], 1)
+        self.assertEquals(response.json()['description'], 'toilet paper')
+
+    def testAssigneeCanUpdateRequest(self):
+        # get the item
+        response = self.client.get('/api/v1/me/assigned-requests/1', HTTP_AUTHORIZATION='Token ' + self.get_token())
+        self.assertEquals(200, response.status_code)
+        updated_data = response.json()
+        updated_data['description'] = '300 rolls of toilet paper'
+
+        response = self.client.put(
+            '/api/v1/me/assigned-requests/1',
+            json.dumps(updated_data),
+            content_type='application/json',
+            HTTP_AUTHORIZATION='Token ' + self.get_token())
+        self.assertEquals(200, response.status_code, response.json())
+
+        response = self.client.get('/api/v1/me/assigned-requests/1', HTTP_AUTHORIZATION='Token ' + self.get_token())
+        self.assertEquals(200, response.status_code)
+        self.assertEquals(response.json()['id'], 1)
+        self.assertEquals(response.json()['description'], '300 rolls of toilet paper', response.json()['type'])
+
+    def get_token(self) -> str:
+        if self.token is not None:
+            return self.token
+        response = self.client.post('/api/v1/auth/login/', {"email": "helper1@email.se", "password": "aoeuaoeu"})
+        self.token = response.json()['token']
+        return self.token

--- a/management/tests.py
+++ b/management/tests.py
@@ -42,7 +42,7 @@ class AssignedRequestsTest(TestCase):
         updated_data = response.json()
         updated_data['description'] = '300 rolls of toilet paper'
 
-        response = self.client.put(
+        response = self.client.patch(
             '/api/v1/me/assigned-requests/1',
             json.dumps(updated_data),
             content_type='application/json',

--- a/management/tests.py
+++ b/management/tests.py
@@ -52,7 +52,7 @@ class AssignedRequestsTest(TestCase):
         response = self.client.get('/api/v1/me/assigned-requests/1', HTTP_AUTHORIZATION='Token ' + self.get_token())
         self.assertEquals(200, response.status_code)
         self.assertEquals(response.json()['id'], 1)
-        self.assertEquals(response.json()['description'], '300 rolls of toilet paper', response.json()['type'])
+        self.assertEquals(response.json()['description'], '300 rolls of toilet paper')
 
     def get_token(self) -> str:
         if self.token is not None:

--- a/management/tests.py
+++ b/management/tests.py
@@ -25,14 +25,14 @@ class AssignedRequestsTest(TestCase):
         self.assertEquals(1, response.json()['count'])
 
     def testAssignedRequestViewEndpointExists(self):
-        response = self.client.get('/api/v1/me/assigned-requests/1')
+        response = self.client.get('/api/v1/me/assigned-requests/1/')
         self.assertEquals(401, response.status_code)
 
     def testOnlyAssigneeCanSeeAssignedRequest(self):
-        response = self.client.get('/api/v1/me/assigned-requests/2',  HTTP_AUTHORIZATION='Token ' + self.get_token())
+        response = self.client.get('/api/v1/me/assigned-requests/2/',  HTTP_AUTHORIZATION='Token ' + self.get_token())
         self.assertEquals(403, response.status_code)
 
-        response = self.client.get('/api/v1/me/assigned-requests/1', HTTP_AUTHORIZATION='Token ' + self.get_token())
+        response = self.client.get('/api/v1/me/assigned-requests/1/', HTTP_AUTHORIZATION='Token ' + self.get_token())
         self.assertEquals(200, response.status_code)
         self.assertEquals(response.json()['id'], 1)
         self.assertEquals(response.json()['description'], 'toilet paper')
@@ -43,20 +43,20 @@ class AssignedRequestsTest(TestCase):
         }
 
         response = self.client.patch(
-            '/api/v1/me/assigned-requests/1',
+            '/api/v1/me/assigned-requests/1/',
             json.dumps(updated_data),
             content_type='application/json',
             HTTP_AUTHORIZATION='Token ' + self.get_token())
         self.assertEquals(200, response.status_code, response.json())
 
-        response = self.client.get('/api/v1/me/assigned-requests/1', HTTP_AUTHORIZATION='Token ' + self.get_token())
+        response = self.client.get('/api/v1/me/assigned-requests/1/', HTTP_AUTHORIZATION='Token ' + self.get_token())
         self.assertEquals(200, response.status_code)
         self.assertEquals(response.json()['id'], 1)
         self.assertEquals(response.json()['status'], Request.STATUS_FINISHED)
 
     def testAssigneeCanOnlyUpdateStatus(self):
         # get the item
-        response = self.client.get('/api/v1/me/assigned-requests/1', HTTP_AUTHORIZATION='Token ' + self.get_token())
+        response = self.client.get('/api/v1/me/assigned-requests/1/', HTTP_AUTHORIZATION='Token ' + self.get_token())
         self.assertEquals(200, response.status_code)
 
         original_data = response.json()
@@ -64,7 +64,7 @@ class AssignedRequestsTest(TestCase):
         updated_data['description'] = 'I really do not want anything'
 
         response = self.client.patch(
-            '/api/v1/me/assigned-requests/1',
+            '/api/v1/me/assigned-requests/1/',
             json.dumps(updated_data),
             content_type='application/json',
             HTTP_AUTHORIZATION='Token ' + self.get_token())
@@ -72,13 +72,13 @@ class AssignedRequestsTest(TestCase):
 
         # test setting an invalid status
         response = self.client.patch(
-            '/api/v1/me/assigned-requests/1',
+            '/api/v1/me/assigned-requests/1/',
             json.dumps({"status": Request.STATUS_CANCELLED}),
             content_type='application/json',
             HTTP_AUTHORIZATION='Token ' + self.get_token())
         self.assertEquals(400, response.status_code, response.json())
 
-        response = self.client.get('/api/v1/me/assigned-requests/1', HTTP_AUTHORIZATION='Token ' + self.get_token())
+        response = self.client.get('/api/v1/me/assigned-requests/1/', HTTP_AUTHORIZATION='Token ' + self.get_token())
         self.assertEquals(200, response.status_code)
         self.assertEquals(response.json()['id'], 1)
         self.assertNotEqual(response.json()['description'], 'I really do not want anything')

--- a/management/urls_v1.py
+++ b/management/urls_v1.py
@@ -13,5 +13,5 @@ urlpatterns = [
     path("requests/", ListCreateRequestsAPIV1.as_view(), name="create_list_requests"),
     path("requests/<int:pk>/", MeRequestDetailAPIV1.as_view(), name="detail_request"),
     path("assigned-requests/", MeAssignedRequestsAPIV1.as_view()),
-    path("assigned-requests/<int:pk>", MeAssignedRequestViewUpdateAPIV1.as_view({'get': 'retrieve', 'patch': 'partial_update'})),
+    path("assigned-requests/<int:pk>/", MeAssignedRequestViewUpdateAPIV1.as_view({'get': 'retrieve', 'patch': 'partial_update'})),
 ]

--- a/management/urls_v1.py
+++ b/management/urls_v1.py
@@ -13,5 +13,5 @@ urlpatterns = [
     path("requests/", ListCreateRequestsAPIV1.as_view(), name="create_list_requests"),
     path("requests/<int:pk>/", MeRequestDetailAPIV1.as_view(), name="detail_request"),
     path("assigned-requests/", MeAssignedRequestsAPIV1.as_view()),
-    path("assigned-requests/<int:pk>", MeAssignedRequestViewUpdateAPIV1.as_view()),
+    path("assigned-requests/<int:pk>", MeAssignedRequestViewUpdateAPIV1.as_view({'get': 'retrieve', 'patch': 'partial_update'})),
 ]

--- a/management/urls_v1.py
+++ b/management/urls_v1.py
@@ -4,10 +4,14 @@ from management.views import (
     ListCreateRequestsAPIV1,
     MeRequestDetailAPIV1,
     MeRetrieveUpdateAPIViewV1,
+    MeAssignedRequestsAPIV1,
+    MeAssignedRequestViewUpdateAPIV1
 )
 
 urlpatterns = [
     path("", MeRetrieveUpdateAPIViewV1.as_view(), name="me_retrieve_update"),
     path("requests/", ListCreateRequestsAPIV1.as_view(), name="create_list_requests"),
     path("requests/<int:pk>/", MeRequestDetailAPIV1.as_view(), name="detail_request"),
+    path("assigned-requests/", MeAssignedRequestsAPIV1.as_view()),
+    path("assigned-requests/<int:pk>", MeAssignedRequestViewUpdateAPIV1.as_view()),
 ]

--- a/management/views.py
+++ b/management/views.py
@@ -40,7 +40,7 @@ class MeRequestDetailAPIV1(generics.RetrieveUpdateDestroyAPIView):
 
     def destroy(self, request, *args, **kwargs):
         request_object = self.get_object()
-        request_object.status = "C"
+        request_object.status = Request.STATUS_CANCELLED
         request_object.save()
         return self.retrieve(request=request, *args, **kwargs)
 

--- a/management/views.py
+++ b/management/views.py
@@ -59,9 +59,6 @@ class MeAssignedRequestsAPIV1(generics.ListAPIView):
 class MeAssignedRequestViewUpdateAPIV1(generics.RetrieveUpdateAPIView):
     permission_classes = [IsAuthenticated, IsAssigneeOfRequest]
     serializer_class = RequestSerializer
-
-    def get_queryset(self):
-        return Request.objects.filter(assignee__user=self.request.user, id=self.kwargs.get("pk", None))
-
+    
     def get_object(self):
-        return Request.objects.get(assignee__user=self.request.user, id=self.kwargs.get("pk", None))
+        return Request.objects.get(id=self.kwargs.get("pk", None))

--- a/management/views.py
+++ b/management/views.py
@@ -2,14 +2,14 @@
 
 
 # Create your views here.
-from rest_framework import generics
+from rest_framework import generics, viewsets
 from rest_framework.permissions import IsAuthenticated
 
 from authentication.permissions import IsAffectedUser, IsOwnerOfRequest, IsAssigneeOfRequest
 from authentication.serializer import ParticipantSerializer
 from crisis.models import Request
 from management.models import Participant
-from management.serializer import RequestSerializer
+from management.serializer import RequestSerializer, AssigneeRequestUpdateSerializer
 
 
 class MeRetrieveUpdateAPIViewV1(generics.RetrieveUpdateAPIView):
@@ -56,9 +56,16 @@ class MeAssignedRequestsAPIV1(generics.ListAPIView):
         return Request.objects.filter(assignee__user=self.request.user)
 
 
-class MeAssignedRequestViewUpdateAPIV1(generics.RetrieveUpdateAPIView):
+class MeAssignedRequestViewUpdateAPIV1(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated, IsAssigneeOfRequest]
     serializer_class = RequestSerializer
+    assignee_serializer_class = AssigneeRequestUpdateSerializer
 
     def get_object(self):
         return Request.objects.get(id=self.kwargs.get("pk", None))
+
+    def get_serializer_class(self):
+        if self.action == 'partial_update':
+            return self.assignee_serializer_class
+
+        return super().get_serializer_class()

--- a/management/views.py
+++ b/management/views.py
@@ -5,7 +5,7 @@
 from rest_framework import generics
 from rest_framework.permissions import IsAuthenticated
 
-from authentication.permissions import IsAffectedUser, IsOwnerOfRequest
+from authentication.permissions import IsAffectedUser, IsOwnerOfRequest, IsAssigneeOfRequest
 from authentication.serializer import ParticipantSerializer
 from crisis.models import Request
 from management.models import Participant
@@ -46,3 +46,22 @@ class MeRequestDetailAPIV1(generics.RetrieveUpdateDestroyAPIView):
 
     def get_object(self):
         return Request.objects.get(id=self.kwargs.get("pk", None))
+
+
+class MeAssignedRequestsAPIV1(generics.ListAPIView):
+    permission_classes = [IsAuthenticated]
+    serializer_class = RequestSerializer
+
+    def get_queryset(self):
+        return Request.objects.filter(assignee__user=self.request.user)
+
+
+class MeAssignedRequestViewUpdateAPIV1(generics.RetrieveUpdateAPIView):
+    permission_classes = [IsAuthenticated, IsAssigneeOfRequest]
+    serializer_class = RequestSerializer
+
+    def get_queryset(self):
+        return Request.objects.filter(assignee__user=self.request.user, id=self.kwargs.get("pk", None))
+
+    def get_object(self):
+        return Request.objects.get(assignee__user=self.request.user, id=self.kwargs.get("pk", None))

--- a/management/views.py
+++ b/management/views.py
@@ -59,6 +59,6 @@ class MeAssignedRequestsAPIV1(generics.ListAPIView):
 class MeAssignedRequestViewUpdateAPIV1(generics.RetrieveUpdateAPIView):
     permission_classes = [IsAuthenticated, IsAssigneeOfRequest]
     serializer_class = RequestSerializer
-    
+
     def get_object(self):
         return Request.objects.get(id=self.kwargs.get("pk", None))


### PR DESCRIPTION
This MR adds a new endpoint for an assignee to view its requests at `/api/v1/me/assigned-requests/`and `/api/v1/me/assigned-requests/[id]`

